### PR TITLE
Use Terraform Registry download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,7 @@ Manages external Terraform modules, controlled by a `Terrafile`.
 
 This is basically a Python version of the tool described at [http://bensnape.com/2016/01/14/terraform-design-patterns-the-terrafile/](http://bensnape.com/2016/01/14/terraform-design-patterns-the-terrafile/)
 
-Additionally pterrafile supports modules from Terraform Registry as well as modules in local directories, identified by a relative path starting with either `./` or `../`.
-
-
-```shell
-# registry module
-tf-aws-lambda:
-  source: "claranet/lambda/aws"
-  version: "v0.1.0"
-
-# local module
-tf-aws-test:
-  source: "../../modules/tf-aws-test"
-```
+Additionally, python-terrafile supports modules from the Terraform Registry, as well as modules in local directories identified by a relative path starting with either `./` or `../` or an absolute path starting with `/`.
 
 ## Installation
 
@@ -31,3 +19,26 @@ pterrafile [path]
 ```
 
 If `path` is provided, it must be the path to a `Terrafile` file, or a directory containing one. If not provided, it looks for the file in the current working directory.
+
+## Examples
+
+```yaml
+# Terraform Registry module
+terraform-aws-lambda:
+  source: "claranet/lambda/aws"
+  version: "0.7.0"
+
+# Git module (HTTPS)
+terraform-aws-lambda:
+  source: "https://github.com/claranet/terraform-aws-lambda.git"
+  version: "v0.7.0"
+
+# Git module (SSH)
+terraform-aws-lambda:
+  source: "git@github.com:claranet/terraform-aws-lambda.git"
+  version: "v0.7.0"
+
+# Local directory module
+terraform-aws-lambda:
+  source: "../../modules/terraform-aws-lambda"
+```


### PR DESCRIPTION
The version tags used on the Terraform Registry don't necessarily match those in the repo, e.g. `0.7.0` compared to `v0.7.0`. This change uses the Terraform Registry download URL to determine the GitHub download URL, and grabs the repo version tag from that.

Another change is to make local filesystem modules only work if they start with certain characters, and to not check if they exist or not. If they don't exist, it will error. The paths must also be relative to the Terrafile (pterrafile can run from a different directory, so behaviour would have been inconsistent).