### PR TITLE
Fixes PyYAML 5.1 deprecation warning

### DIFF
--- a/terrafile/__init__.py
+++ b/terrafile/__init__.py
@@ -58,7 +58,7 @@ def get_terrafile_path(path):
 def read_terrafile(path):
     try:
         with open(path) as open_file:
-            terrafile = yaml.load(open_file)
+            terrafile = yaml.load(open_file, Loader=yaml.FullLoader)
         if not terrafile:
             raise ValueError('{} is empty'.format(path))
     except IOError as error:

--- a/terrafile/__init__.py
+++ b/terrafile/__init__.py
@@ -58,7 +58,7 @@ def get_terrafile_path(path):
 def read_terrafile(path):
     try:
         with open(path) as open_file:
-            terrafile = yaml.load(open_file, Loader=yaml.FullLoader)
+            terrafile = yaml.safe_load(open_file)
         if not terrafile:
             raise ValueError('{} is empty'.format(path))
     except IOError as error:


### PR DESCRIPTION
PyYAML 5.1 outputs a warning if a Loader argument isn't present.  This specifies an argument and suppresses the warning.

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation